### PR TITLE
Added hash option to add compilation hash to the filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ module.exports = {
 
             // REQUIRED.
             // Name of the file to add to assets.
+            // if hash option is enabled add [hash] here to choose where to insert the compilation hash
+            // see the hash option for more information
             filename: `index.js`,
 
             // REQUIRED.
@@ -46,7 +48,13 @@ module.exports = {
             // OPTIONAL: defaults to the webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL.
             // Asset processing stage.
             // https://webpack.js.org/api/compilation-hooks/#processassets
-            stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+            stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
+
+            // OPTIONAL
+            // Adds the compilation hash to the filename. You can either choose within the filename
+            // where the hash is inserted by adding [hash] i.e. test.[hash].js or the hash will be
+            // appended to the end of the file i.e. test.js?hash
+            hash: false
         })
     ]
 };

--- a/index.js
+++ b/index.js
@@ -91,6 +91,14 @@ EmitFilePlugin.prototype.apply = function (compiler) {
 function emitFile(options, compilation, resolve) {
     const outputPath = options.path || compilation.options.output.path;
 
+    if (options.hash) {
+      if (options.filename.includes('[hash]')) {
+        options.filename = options.filename.replace('[hash]', compilation.hash);
+      } else {
+        options.filename = `${options.filename}?${compilation.hash}`;
+      }
+    }
+
     const outputPathAndFilename = path.resolve(
         compilation.options.output.path,
         outputPath,

--- a/index.js
+++ b/index.js
@@ -91,18 +91,20 @@ EmitFilePlugin.prototype.apply = function (compiler) {
 function emitFile(options, compilation, resolve) {
     const outputPath = options.path || compilation.options.output.path;
 
+    let filename = options.filename;
+
     if (options.hash) {
       if (options.filename.includes('[hash]')) {
-        options.filename = options.filename.replace('[hash]', compilation.hash);
+        filename = options.filename.replace('[hash]', compilation.hash);
       } else {
-        options.filename = `${options.filename}?${compilation.hash}`;
+        filename = `${options.filename}?${compilation.hash}`;
       }
     }
 
     const outputPathAndFilename = path.resolve(
         compilation.options.output.path,
         outputPath,
-        options.filename
+		filename
     );
 
     const relativeOutputPath = path.relative(

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ function emitFile(options, compilation, resolve) {
     const outputPathAndFilename = path.resolve(
         compilation.options.output.path,
         outputPath,
-		filename
+        filename
     );
 
     const relativeOutputPath = path.relative(


### PR DESCRIPTION
In my code base I had something very similar to this plugin that worked fine back for webpack 4 and instead of updating it for webpack 5 I decided to look at your plugin instead. I noticed the only thing missing was the ability to add the compilation hash to the filename. The hash is generally added to help with cache busting so I found it pretty easy to just add a hash boolean to your options object to accomplish my goal. I also updated your README to reflect this new option. Not sure if you wanted this added to yours but I figured I would submit a pull request just in case.